### PR TITLE
Sharing an image on Android API >= 24 failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+.vscode/
 demo/lib/
 demo/platforms/
 demo/node_modules/

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
 		"NativeScript"
 	],
 	"author": "TJ VanToll <tj.vantoll@gmail.com> (http://tjvantoll.com/)",
+	"contributors": [
+		{
+			"name": "Eddy Verbruggen",
+			"email": "eddyverbruggen@gmail.com",
+			"url": "https://github.com/EddyVerbruggen"
+		}
+	],
 	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/tjvantoll/nativescript-social-share/issues"

--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<application>
+		<provider
+			android:name="android.support.v4.content.FileProvider"
+			android:authorities="${applicationId}.provider"
+			android:exported="false"
+			android:grantUriPermissions="true">
+			<meta-data
+				android:name="android.support.FILE_PROVIDER_PATHS"
+				android:resource="@xml/provider_paths"/>
+		</provider>
+	</application>
+</manifest>

--- a/platforms/android/res/xml/provider_paths.xml
+++ b/platforms/android/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>

--- a/social-share.android.js
+++ b/social-share.android.js
@@ -1,4 +1,5 @@
 var application = require("application");
+var platform = require("platform");
 var context;
 var numberOfImagesCreated = 0;
 
@@ -36,8 +37,14 @@ module.exports = {
 		fos.flush();
 		fos.close();
 
-		intent.putExtra(android.content.Intent.EXTRA_STREAM,
-			android.net.Uri.fromFile(newFile));
+    var shareableFileUri;
+    var sdkVersionInt = parseInt(platform.device.sdkVersion);
+    if (sdkVersionInt >= 21) {
+      shareableFileUri = android.support.v4.content.FileProvider.getUriForFile(context, application.android.nativeApp.getPackageName() + ".provider", newFile);
+    } else {
+      shareableFileUri = android.net.Uri.fromFile(newFile);
+    }
+    intent.putExtra(android.content.Intent.EXTRA_STREAM, shareableFileUri);
 
 		share(intent, subject);
 	},


### PR DESCRIPTION
Since Android 7 you must use the `FileProvider` class to share files (an image in this case) between apps.

This PR is inspired by changes I did previously in the Cordova SocialSharing plugin, and simalr changes I encountered in nativescript-camera. Speaking of which: I've tested compatibility with the Camera plugin: if you leave the changes to `AndroidManifest.xml` as I'm proposing, then these plugins can coexist in harmony inside one app.