### PR TITLE
fix(iOS): sharing pane now opens over topmost view controller properly

### DIFF
--- a/social-share.ios.js
+++ b/social-share.ios.js
@@ -15,9 +15,7 @@ function share(thingsToShare, index) {
 		}
 	}
 
-	utilsModule.ios.getter(UIApplication, UIApplication.sharedApplication)
-		.keyWindow
-		.rootViewController
+	frameModule.topmost().ios.controller
 		.presentViewControllerAnimatedCompletion(activityController, true, null);
 }
 


### PR DESCRIPTION
closes https://github.com/tjvantoll/nativescript-social-share/issues/20