### PR TITLE
Render above visible view controller to make it useable from a modal

### DIFF
--- a/src/social-share.ios.ts
+++ b/src/social-share.ios.ts
@@ -15,7 +15,7 @@ function share(thingsToShare) {
     }
   }
 
-  topmost().ios.controller
+  topmost().ios.controller.visibleViewController
     .presentViewControllerAnimatedCompletion(activityController, true, null);
 }
 


### PR DESCRIPTION
When using nativescript Angular, this popup would render under a modal if it was triggered from there. By using the visible view controller instead, this is rendered on top of the modal.